### PR TITLE
Set IBM PowerVC specific vendor

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -19,11 +19,11 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
   supports :metrics
 
   def self.vm_vendor
-    "ibm"
+    "ibm_power_vc"
   end
 
   def image_name
-    "power_vc"
+    "ibm_power_vc"
   end
 
   def self.params_for_create

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
@@ -10,4 +10,8 @@ class ManageIQ::Providers::IbmPowerVc::NetworkManager < ManageIQ::Providers::Ope
   def self.description
     @description ||= "IBM PowerVC Network".freeze
   end
+
+  def image_name
+    "ibm_power_vc"
+  end
 end

--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
@@ -67,7 +67,7 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
     def assert_specific_vm
       vm = ems.vms.find_by(:ems_ref => "42420bf6-e08e-4360-85b0-4dea6e80344f")
       expect(vm).to have_attributes(
-        :vendor            => "ibm",
+        :vendor            => "ibm_power_vc",
         :name              => "RHEL82_100GB-test",
         :description       => nil,
         :location          => "unknown",


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq-providers-ibm_cloud/issues/243

Use IBM PowerVC specific vendor and icon names to differentiate from
other IBM providers (IBM Cloud).

Depends on
- https://github.com/ManageIQ/manageiq/pull/21333
- https://github.com/ManageIQ/manageiq-decorators/pull/50

Fixes #10