### PR TITLE
Skip Image Export (node) credential validation

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -470,4 +470,21 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
   def self.description
     @description ||= "IBM PowerVC".freeze
   end
+
+  def required_credential_fields(type)
+    case type.to_s
+    when 'ssh_keypair' then [:userid, :auth_key]
+    when 'node' then [:userid]
+    else                    [:userid, :password]
+    end
+  end
+
+  def authentication_status_ok?(type = nil)
+    return true if [:ssh_keypair, :node].include(type)
+    super
+  end
+
+  def authentications_to_validate
+    authentication_for_providers.collect(&:authentication_type) - [:ssh_keypair, :node]
+  end
 end


### PR DESCRIPTION
The credentials used for Image Export don't have validation logic,
causing over-all provider credential validation to fail. This blocks
provider refresh from the GUI.

In the future, we should add validation to these credentials if the user
provides them (Image Export is an optional feature, so credentials also
need to be optional).