### PR TITLE
console_url to return the endpoint details

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -18,6 +18,7 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
 
   supports :create
   supports :metrics
+  supports :native_console
 
   has_one :network_manager,
           :foreign_key => :parent_ems_id,
@@ -34,6 +35,10 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
 
   def self.vm_vendor
     "ibm_power_vc"
+  end
+
+  def console_url
+    "https://#{endpoint.hostname}"
   end
 
   def image_name


### PR DESCRIPTION
Requires:
- [x] https://github.com/ManageIQ/manageiq/pull/21778

Required by:
- [ ] https://github.com/ManageIQ/manageiq-ui-classic/pull/8149

This function is required as it returns the url required for the PowerVC Cloud Provider Web Console dynamically.
