### PR TITLE
Inventory sub-classes

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/inventory.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory.rb
@@ -1,5 +1,4 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory < ManageIQ::Providers::Openstack::Inventory
-  require_nested :Collector
   require_nested :Parser
   require_nested :Persister
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory.rb
@@ -1,4 +1,15 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory < ManageIQ::Providers::Openstack::Inventory
   require_nested :Parser
   require_nested :Persister
+
+  def self.parser_classes_for(_ems, target)
+    case target
+    when InventoryRefresh::TargetCollection
+      [ManageIQ::Providers::IbmPowerVc::Inventory::Parser::CloudManager,
+       ManageIQ::Providers::IbmPowerVc::Inventory::Parser::NetworkManager,
+       ManageIQ::Providers::IbmPowerVc::Inventory::Parser::StorageManager::CinderManager]
+    else
+      super
+    end
+  end
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/collector.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/collector.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::IbmPowerVc::Inventory::Collector < ManageIQ::Providers::Openstack::Inventory::Collector
-  require_nested :CloudManager
-end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/collector/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/collector/cloud_manager.rb
@@ -1,2 +1,0 @@
-class ManageIQ::Providers::IbmPowerVc::Inventory::Collector::CloudManager < ManageIQ::Providers::Openstack::Inventory::Collector::CloudManager
-end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser.rb
@@ -1,3 +1,5 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory::Parser < ManageIQ::Providers::Openstack::Inventory::Parser
   require_nested :CloudManager
+  require_nested :NetworkManager
+  require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser/network_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmPowerVc::Inventory::Parser::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Parser::NetworkManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::IbmPowerVc::Inventory::Parser::StorageManager
+  require_nested :CinderManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager/cinder_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmPowerVc::Inventory::Parser::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Parser::StorageManager::CinderManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister.rb
@@ -1,3 +1,10 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory::Persister < ManageIQ::Providers::Openstack::Inventory::Persister
   require_nested :CloudManager
+  require_nested :NetworkManager
+  require_nested :StorageManager
+  require_nested :TargetCollection
+
+  def cinder_manager
+    manager.kind_of?(ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager) ? manager : manager.cinder_manager
+  end
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/definitions/cloud_collections.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/definitions/cloud_collections.rb
@@ -1,3 +1,0 @@
-module ManageIQ::Providers::IbmPowerVc::Inventory::Persister::Definitions::CloudCollections
-  include ManageIQ::Providers::Openstack::Inventory::Persister::Definitions::CloudCollections
-end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/network_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmPowerVc::Inventory::Persister::NetworkManager < ManageIQ::Providers::Openstack::Inventory::Persister::NetworkManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager.rb
@@ -1,0 +1,3 @@
+module ManageIQ::Providers::IbmPowerVc::Inventory::Persister::StorageManager
+  require_nested :CinderManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager/cinder_manager.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::IbmPowerVc::Inventory::Persister::StorageManager::CinderManager < ManageIQ::Providers::Openstack::Inventory::Persister::StorageManager::CinderManager
+end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/target_collection.rb
@@ -1,0 +1,16 @@
+class ManageIQ::Providers::IbmPowerVc::Inventory::Persister::TargetCollection < ManageIQ::Providers::Openstack::Inventory::Persister::TargetCollection
+  def initialize_cloud_inventory_collections
+    super
+    add_advanced_settings
+  end
+
+  def add_advanced_settings
+    add_collection(cloud, :vms_and_templates_advanced_settings) do |builder|
+      builder.add_properties(
+        :manager_ref                  => %i[resource name],
+        :model_class                  => ::AdvancedSetting,
+        :parent_inventory_collections => %i[vms]
+      )
+    end
+  end
+end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network.rb
@@ -1,4 +1,6 @@
 ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
+  require_nested :Private
+  require_nested :Public
 end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network/private.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network/private.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork::Private < ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (IBM PowerVC)', 'Cloud Networks (IBM PowerVC)', number)
+  end
+end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network/public.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network/public.rb
@@ -1,0 +1,5 @@
+class ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork::Public < ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork
+  def self.display_name(number = 1)
+    n_('Cloud Network (IBM PowerVC)', 'Cloud Networks (IBM PowerVC)', number)
+  end
+end

--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
@@ -30,6 +30,8 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
           assert_specific_cloud_tenant
           assert_specific_flavor
           assert_specific_vm
+          assert_cinder_manager
+          assert_network_manager
         end
       end
     end
@@ -42,6 +44,8 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
       expect(ems.availability_zones.count).to be > 2
       expect(ems.flavors.count).to be > 2
       expect(ems.vms.count).to be > 1
+
+      expect(ems.type).to eq("ManageIQ::Providers::IbmPowerVc::CloudManager")
     end
 
     def assert_specific_availability_zone
@@ -100,6 +104,16 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
         :raw_power_state  => "ACTIVE",
         :power_state      => "on"
       )
+    end
+
+    def assert_cinder_manager
+      cinder_manager = ManageIQ::Providers::StorageManager.find_by(:parent_ems_id => ems.id)
+      expect(cinder_manager.type).to eq("ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager")
+    end
+
+    def assert_network_manager
+      network_manager = ManageIQ::Providers::NetworkManager.find_by(:parent_ems_id => ems.id)
+      expect(network_manager.type).to eq("ManageIQ::Providers::IbmPowerVc::NetworkManager")
     end
 
     def with_vcr(suffix = nil, &block)


### PR DESCRIPTION
Set object `type` using the `ManageIQ::Providers::IbmPowerVc` namespace (instead of `ManageIQ::Providers::Openstack`) by sub-classing ther persister properly.