### PR TITLE
placement group for power vc

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
   require_nested :HostAggregate
   require_nested :MetricsCapture
   require_nested :MetricsCollectorWorker
+  require_nested :PlacementGroup
   require_nested :Refresher
   require_nested :RefreshWorker
   require_nested :Template

--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/placement_group.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/placement_group.rb
@@ -1,0 +1,4 @@
+ManageIQ::Providers::Openstack::CloudManager::PlacementGroup.include(ActsAsStiLeafClass)
+
+class ManageIQ::Providers::IbmPowerVc::CloudManager::PlacementGroup < ManageIQ::Providers::Openstack::CloudManager::PlacementGroup
+end


### PR DESCRIPTION
This shows the placement group of a VM. It is known as server groups or collocation rules in OpenStack terminology.
Please see associated changes in the the manageiq core for this.
1. ManageIQ Openstack changes
   https://github.com/ManageIQ/manageiq-providers-openstack/pull/806
2. Manageiq schema changes.
   https://github.com/ManageIQ/manageiq-schema/pull/644
3. ManageIQ Core changes
    https://github.com/ManageIQ/manageiq/pull/21807
