### PR TITLE
Adding Access > VM Console action & spec for PowerVC

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
@@ -1,4 +1,18 @@
 ManageIQ::Providers::Openstack::CloudManager::Vm.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::CloudManager::Vm < ManageIQ::Providers::Openstack::CloudManager::Vm
+  supports :html5_console do
+    reason   = _("VM Console not supported because VM is not powered on") unless current_state == "on"
+    reason ||= _("VM Console not supported because VM is orphaned")       if orphaned?
+    reason ||= _("VM Console not supported because VM is archived")       if archived?
+    unsupported_reason_add(:html5_console, reason) if reason
+  end
+  supports :launch_html5_console
+
+  def remote_console_acquire_ticket(_userid, _originating_server, _console_type)
+    super
+  rescue => err
+    msg = err.response.reason_phrase == 'Not Implemented' ? 'PowerVM NovaLink is required for VM console access.' : err.response.reason_phrase
+    raise MiqException::MiqVmError, msg
+  end
 end

--- a/spec/factories/vm_or_template.rb
+++ b/spec/factories/vm_or_template.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :vm_ibm_power_vc, :class => "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm", :parent => :vm_cloud do
+    vendor { "ibm_power_vc" }
+
+    trait :with_provider do
+      after(:create) do |x|
+        FactoryBot.create(:ems_ibm_cloud_power_virtual_servers_cloud, :vms => [x])
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/vm_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/vm_spec.rb
@@ -1,0 +1,60 @@
+describe ManageIQ::Providers::IbmPowerVc::CloudManager::Vm do
+  let(:ems)                   { FactoryBot.create(:ems_ibm_power_vc) }
+  let(:vm)                    { FactoryBot.create(:vm_ibm_power_vc, :ext_management_system => ems) }
+  let(:power_state_on)        { "ACTIVE" }
+  let(:power_state_suspended) { "SHUTOFF" }
+
+  context "#supports?" do
+    context "with :start" do
+      let(:state) { :start }
+      include_examples "Vm operation is available when not powered on"
+    end
+
+    context "with :stop" do
+      let(:state) { :stop }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context "with :shutdown_guest" do
+      let(:state) { :shutdown_guest }
+      include_examples "Vm operation is not available"
+    end
+
+    context "with :standby_guest" do
+      let(:state) { :standby_guest }
+      include_examples "Vm operation is not available"
+    end
+
+    context "with :reboot_guest" do
+      let(:state) { :reboot_guest }
+      include_examples "Vm operation is available when powered on"
+    end
+
+    context "with :reset" do
+      let(:state) { :reset }
+      include_examples "Vm operation is available when powered on"
+    end
+  end
+
+  context "supports VM console access?" do
+    it 'supports console access if powered on' do
+      vm.update(:raw_power_state => power_state_on)
+      expect(vm.supports?(:html5_console)).to be_truthy
+    end
+
+    it 'no console access if powered off' do
+      vm.update(:raw_power_state => power_state_suspended)
+      expect(vm.supports?(:html5_console)).to be_falsey
+    end
+
+    it 'no console access if orphaned' do
+      vm.update(:ems_id => nil)
+      expect(vm.supports?(:html5_console)).to be_falsey
+    end
+
+    it 'no console access if archived' do
+      vm.update(:ems_id => nil, :storage_id => nil)
+      expect(vm.supports?(:html5_console)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This change would enable the action for all VMs on a PowerVC, though it'd "work" only when the VM is managed by "Novalink." So, it is suggested this PR to wait for a little enhancement for collecting such info from PowerVC in the db so this action can be enabled only for Novalink VMs.

Ref: https://www.ibm.com/docs/en/powervc/2.0.1?topic=working-virtual-machines

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>