### PR TITLE
adds necessary override for the correct dialog name

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/provision_workflow.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/provision_workflow.rb
@@ -2,4 +2,11 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager::ProvisionWorkflow < ManageI
   def self.provider_model
     ManageIQ::Providers::IbmPowerVc::CloudManager
   end
+
+  private
+
+  def dialog_name_from_automate(message = 'get_dialog_name', extra_attrs = {})
+    extra_attrs['platform'] = 'ibm_power_vc'
+    super(message, extra_attrs)
+  end
 end


### PR DESCRIPTION
This fixes #83 by overriding `dialog_name_from_automate()` to provide the correct platform name: `ibm_power_vc`