### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -23,7 +23,7 @@ class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Opens
   supports :catalog
   supports :create
   supports :metrics
-  supports :native_console
+  supports :management_console
 
   has_one :network_manager,
           :foreign_key => :parent_ems_id,


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name from native_console to management_console since native_console is already used by the RHV provider.