### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager.rb
@@ -1,25 +1,6 @@
 ManageIQ::Providers::Openstack::CloudManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::CloudManager < ManageIQ::Providers::Openstack::CloudManager
-  require_nested :AuthKeyPair
-  require_nested :AvailabilityZone
-  require_nested :AvailabilityZoneNull
-  require_nested :CloudResourceQuota
-  require_nested :CloudTenant
-  require_nested :Provision
-  require_nested :ProvisionWorkflow
-  require_nested :EventCatcher
-  require_nested :Flavor
-  require_nested :HostAggregate
-  require_nested :MetricsCapture
-  require_nested :MetricsCollectorWorker
-  require_nested :PlacementGroup
-  require_nested :Refresher
-  require_nested :RefreshWorker
-  require_nested :Snapshot
-  require_nested :Template
-  require_nested :Vm
-
   supports :catalog
   supports :create
   supports :metrics

--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 ManageIQ::Providers::Openstack::CloudManager::EventCatcher.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::CloudManager::EventCatcher < ManageIQ::Providers::Openstack::CloudManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_ibm_power_vc
   end

--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/metrics_collector_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmPowerVc::CloudManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-  require_nested :Runner
-
   self.default_queue_name = "ibm_power_vc"
 
   def friendly_name

--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::IbmPowerVc::CloudManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_ibm_power_vc
   end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory < ManageIQ::Providers::Openstack::Inventory
-  require_nested :Parser
-  require_nested :Persister
-
   def self.parser_classes_for(_ems, target)
     case target
     when InventoryRefresh::TargetCollection

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory::Parser < ManageIQ::Providers::Openstack::Inventory::Parser
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser/storage_manager.rb
@@ -1,3 +1,2 @@
 module ManageIQ::Providers::IbmPowerVc::Inventory::Parser::StorageManager
-  require_nested :CinderManager
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister.rb
@@ -1,9 +1,4 @@
 class ManageIQ::Providers::IbmPowerVc::Inventory::Persister < ManageIQ::Providers::Openstack::Inventory::Persister
-  require_nested :CloudManager
-  require_nested :NetworkManager
-  require_nested :StorageManager
-  require_nested :TargetCollection
-
   def cinder_manager
     manager.kind_of?(ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager) ? manager : manager.cinder_manager
   end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/storage_manager.rb
@@ -1,3 +1,2 @@
 module ManageIQ::Providers::IbmPowerVc::Inventory::Persister::StorageManager
-  require_nested :CinderManager
 end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
@@ -1,14 +1,6 @@
 ManageIQ::Providers::Openstack::NetworkManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::NetworkManager < ManageIQ::Providers::Openstack::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :EventCatcher
-  require_nested :FloatingIp
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :SecurityGroup
-
   def self.ems_type
     @ems_type ||= "ibm_power_vc_network".freeze
   end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager/cloud_network.rb
@@ -1,6 +1,4 @@
 ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::NetworkManager::CloudNetwork < ManageIQ::Providers::Openstack::NetworkManager::CloudNetwork
-  require_nested :Private
-  require_nested :Public
 end

--- a/app/models/manageiq/providers/ibm_power_vc/network_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 ManageIQ::Providers::Openstack::NetworkManager::EventCatcher.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::NetworkManager::EventCatcher < ManageIQ::Providers::Openstack::NetworkManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_ibm_power_vc_network
   end

--- a/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager.rb
@@ -1,12 +1,6 @@
 ManageIQ::Providers::Openstack::StorageManager::CinderManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager < ManageIQ::Providers::Openstack::StorageManager::CinderManager
-  require_nested :EventCatcher
-  require_nested :CloudVolume
-  require_nested :CloudVolumeBackup
-  require_nested :CloudVolumeSnapshot
-  require_nested :CloudVolumeType
-
   def self.ems_type
     @ems_type ||= "ibm_power_vc_cinder".freeze
   end

--- a/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager/event_catcher.rb
@@ -1,8 +1,6 @@
 ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager::EventCatcher < ManageIQ::Providers::Openstack::StorageManager::CinderManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_ibm_power_vc_cinder
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854