### PR TITLE
drop unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
@@ -2,10 +2,9 @@ ManageIQ::Providers::Openstack::CloudManager::Vm.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::CloudManager::Vm < ManageIQ::Providers::Openstack::CloudManager::Vm
   supports :html5_console do
-    reason   = _("VM Console not supported because VM is not powered on") unless current_state == "on"
-    reason ||= _("VM Console not supported because VM is orphaned")       if orphaned?
-    reason ||= _("VM Console not supported because VM is archived")       if archived?
-    unsupported_reason_add(:html5_console, reason) if reason
+    return _("VM Console not supported because VM is not powered on") unless current_state == "on"
+    return _("VM Console not supported because VM is orphaned")       if orphaned?
+    return _("VM Console not supported because VM is archived")       if archived?
   end
   supports :launch_html5_console
 


### PR DESCRIPTION
part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
