### PR TITLE
Add OS Version directly to operating_system data

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/inventory/parser/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/parser/cloud_manager.rb
@@ -3,6 +3,9 @@ class ManageIQ::Providers::IbmPowerVc::Inventory::Parser::CloudManager < ManageI
     super
     server = persister.vms.find_or_build(vm.id.to_s)
 
+    operating_system = persister.operating_systems.find(server)
+    operating_system.name = vm.attributes['operating_system'].to_s if vm.attributes.key?('operating_system')
+
     persister.vms_and_templates_advanced_settings.build(
       :resource     => server,
       :display_name => N_('Operating system'),

--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
@@ -19,6 +19,7 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
           assert_specific_cloud_tenant
           assert_specific_flavor
           assert_specific_vm
+          assert_specific_operating_system
           assert_cinder_manager
           assert_network_manager
         end
@@ -92,6 +93,15 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
         :cloud_tenant     => ems.cloud_tenants.find_by(:ems_ref => tenantid),
         :raw_power_state  => "ACTIVE",
         :power_state      => "on"
+      )
+    end
+
+    def assert_specific_operating_system
+      vm = ems.vms.find_by(:ems_ref => instid)
+      os = vm.operating_system
+      expect(os).to have_attributes(
+        :product_name => "linux_redhat",
+        :name         => "Linux/CentOS Stream 4.18.0-408.el8.ppc64le 8"
       )
     end
 


### PR DESCRIPTION
PowerVC provides an `operating_system` attribute for VMs. This is already persisted as an `advanced_setting`, but that makes including it in reports more difficult. This commit sets this value to `operating_system` ~`version`~ `name` in addition to `advanced_setting` in order to allow it to be included in VM reports directly as the ~`OS : Version`~ `OS : Name`.

Related UI PR:
https://github.com/ManageIQ/manageiq-ui-classic/pull/9110