### PR TITLE
Remove return from supports block

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/vm.rb
@@ -2,9 +2,13 @@ ManageIQ::Providers::Openstack::CloudManager::Vm.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::CloudManager::Vm < ManageIQ::Providers::Openstack::CloudManager::Vm
   supports :html5_console do
-    return _("VM Console not supported because VM is not powered on") unless current_state == "on"
-    return _("VM Console not supported because VM is orphaned")       if orphaned?
-    return _("VM Console not supported because VM is archived")       if archived?
+    if current_state != "on"
+      _("VM Console not supported because VM is not powered on")
+    elsif orphaned?
+      _("VM Console not supported because VM is orphaned")
+    elsif archived?
+      _("VM Console not supported because VM is archived")
+    end
   end
   supports :launch_html5_console
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/22898 (as a followup)

Introduced by https://github.com/ManageIQ/manageiq-providers-ibm_power_vc/pull/103

You can not have a return in a block. It causes a LongJump error Besides, it tries to return from inside the calling block - not what we want.
