### PR TITLE
Delegate refresh_ems class method to parent cloud manager

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/network_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::NetworkManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::NetworkManager < ManageIQ::Providers::Openstack::NetworkManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmPowerVc::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_power_vc_network".freeze
   end

--- a/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/storage_manager/cinder_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::StorageManager::CinderManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::StorageManager::CinderManager < ManageIQ::Providers::Openstack::StorageManager::CinderManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmPowerVc::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_power_vc_cinder".freeze
   end

--- a/app/models/manageiq/providers/ibm_power_vc/storage_manager/swift_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/storage_manager/swift_manager.rb
@@ -1,6 +1,10 @@
 ManageIQ::Providers::Openstack::StorageManager::SwiftManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::IbmPowerVc::StorageManager::SwiftManager < ManageIQ::Providers::Openstack::StorageManager::SwiftManager
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::IbmPowerVc::CloudManager
+  end
+
   def self.ems_type
     @ems_type ||= "ibm_power_vc_swift".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,10 +7,14 @@
     :parallel_thread_limit: 0
   :ibm_power_vc_network:
     :is_admin: false
+    :refresh_interval: 0
   :ibm_power_vc_infra:
     :is_admin: false
-  :cinder:
+  :ibm_power_vc_cinder:
     :is_admin: false
+    :refresh_interval: 0
+  :ibm_power_vc_swift:
+    :refresh_interval: 0
 :ems:
   :ems_ibm_power_vc:
     :min_supported_rel: '1.4.4'


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare