### PR TITLE
[WIP] Reconnect archived PowerHMC VIOS Vms

### DIFF
--- a/app/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher.rb
@@ -1,2 +1,7 @@
 class ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher < ManageIQ::Providers::Openstack::CloudManager::Refresher
+  def save_inventory(ems, target, inventory_collections)
+    super
+    # Queue refresh for each of our child HMCs if we are performing a full refresh
+    EmsRefresh.queue_refresh(ems.ibm_power_hmcs.pluck(:type, :id)) if target.kind_of?(ManageIQ::Providers::BaseManager)
+  end
 end

--- a/app/models/manageiq/providers/ibm_power_vc/inventory/persister/cloud_manager.rb
+++ b/app/models/manageiq/providers/ibm_power_vc/inventory/persister/cloud_manager.rb
@@ -13,4 +13,53 @@ class ManageIQ::Providers::IbmPowerVc::Inventory::Persister::CloudManager < Mana
       )
     end
   end
+
+  def add_vms
+    add_cloud_collection(:vms) do |builder|
+      builder.add_default_values(:vendor => manager.class.vm_vendor)
+      builder.add_properties(:custom_reconnect_block => power_hmc_reconnect_block)
+    end
+  end
+
+  private
+
+  def power_hmc_reconnect_block
+    lambda do |inventory_collection, inventory_objects_index, attributes_index|
+      ems_ids = [nil, manager.id] + manager.ibm_power_hmcs.pluck(:id)
+
+      relation = Vm.where(
+        :ems_id => ems_ids,
+        :type   => [
+          "ManageIQ::Providers::IbmPowerHmc::InfraManager::Vios",
+          "ManageIQ::Providers::IbmPowerVc::CloudManager::Vm"
+        ]
+      )
+
+      return if relation.count <= 0
+
+      inventory_objects_index.each_slice(100) do |batch|
+        batch_refs = batch.map(&:first)
+        relation.where(inventory_collection.manager_ref.first => batch_refs).order(:id => :asc).each do |record|
+          index = inventory_collection.object_index_with_keys(inventory_collection.manager_ref_to_cols, record)
+
+          # We need to delete the record from the inventory_objects_index
+          # and attributes_index, otherwise it would be sent for create.
+          inventory_object = inventory_objects_index.delete(index)
+          hash             = attributes_index.delete(index)
+
+          # Skip if hash is blank, which can happen when having several archived entities with the same ref
+          next unless hash
+
+          assignable_hash = hash.except(:id).slice(*record.attribute_names.map(&:to_sym))
+          record.assign_attributes(assignable_hash)
+          if !inventory_collection.check_changed? || record.changed?
+            record.save!
+            inventory_collection.store_updated_records(record)
+          end
+
+          inventory_object.id = record.id
+        end
+      end
+    end
+  end
 end

--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
@@ -12,10 +12,7 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
     context "full refresh" do
       it "Performs a full refresh" do
         2.times do
-          with_vcr do
-            reset_cache
-            refresh(ems)
-          end
+          with_vcr { refresh(ems) }
 
           assert_ems
           assert_specific_availability_zone
@@ -25,6 +22,54 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
           assert_specific_operating_system
           assert_cinder_manager
           assert_network_manager
+        end
+      end
+    end
+
+    describe "reconnects PowerVC VMs" do
+      let!(:archived_vm) { FactoryBot.create(:vm_ibm_power_vc, :ems_id => nil, :uid_ems => instid, :ems_ref => instid) }
+
+      it "reconnects the VM" do
+        with_vcr { refresh(ems) }
+
+        expect(archived_vm.reload.ext_management_system).to eq(ems)
+      end
+    end
+
+    describe "reconnects HMC VMs" do
+      context "with an archived HMC" do
+        let!(:power_hmc_vios) { FactoryBot.create(:ibm_power_hmc_vios, :uid_ems => instid, :ems_ref => instid) }
+
+        it "reconnects the HMC Vios" do
+          with_vcr { refresh(ems) }
+
+          # power_hmc_vios can't be reloaded here because the :type column changed
+          expect(ems.vms.find_by(:ems_ref => power_hmc_vios.ems_ref).id).to eq(power_hmc_vios.id)
+        end
+      end
+
+      context "with an active HMC vm" do
+        let!(:power_hmc_vios) { FactoryBot.create(:ibm_power_hmc_vios, :uid_ems => instid, :ems_ref => instid, :ext_management_system => ems_hmc) }
+
+        context "that is linked with our PowerVC provider" do
+          let(:ems_hmc) { FactoryBot.create(:ems_ibm_power_hmc_infra, :zone => zone, :parent_manager => ems) }
+
+          it "reconnects the HMC Vios" do
+            with_vcr { refresh(ems) }
+
+            # power_hmc_vios can't be reloaded here because the :type column changed
+            expect(ems.vms.find_by(:ems_ref => power_hmc_vios.ems_ref).id).to eq(power_hmc_vios.id)
+          end
+        end
+
+        context "that is not linked with our PowerVC provider" do
+          let(:ems_hmc) { FactoryBot.create(:ems_ibm_power_hmc_infra, :zone => zone) }
+
+          it "doesn't reconnect the HMC Vios" do
+            with_vcr { refresh(ems) }
+
+            expect(ems.vms.find_by(:ems_ref => power_hmc_vios.ems_ref).id).not_to eq(power_hmc_vios.id)
+          end
         end
       end
     end
@@ -133,6 +178,7 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
     end
 
     def refresh(targets)
+      reset_cache
       described_class.refresh(Array(targets))
     end
   end


### PR DESCRIPTION
Allow any archived/orphaned HMC VIOS VMs to be automatically picked up by the PowerVC refresh.

This allows for associated PowerHMC systems to skip collection of existing VM records, have those VMs associated with the PowerVC, without having those records be deleted and recreated.

https://github.com/ManageIQ/manageiq/issues/23755
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
