### PR TITLE
Fix fog cache causing errors refreshing twice

### DIFF
--- a/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/ibm_power_vc/cloud_manager/refresher_spec.rb
@@ -11,8 +11,11 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
   describe "#refresh" do
     context "full refresh" do
       it "Performs a full refresh" do
-        1.times do
-          with_vcr { refresh(ems) }
+        2.times do
+          with_vcr do
+            reset_cache
+            refresh(ems)
+          end
 
           assert_ems
           assert_specific_availability_zone
@@ -24,6 +27,13 @@ describe ManageIQ::Providers::IbmPowerVc::CloudManager::Refresher do
           assert_network_manager
         end
       end
+    end
+
+    def reset_cache
+      ems.reset_openstack_handle
+
+      require "fog/openstack"
+      Fog::OpenStack.instance_variable_set(:@version, nil)
     end
 
     def assert_ems


### PR DESCRIPTION
Typically refresher specs run the full refresh twice to confirm that nothing changes when refreshing the same source inventory.

Openstack's fog-openstack gem caches certain API calls which caused `2.times { with_vcr { refresh(ems) } }` to fail with missing vcr calls.

Resetting the openstack handle and cached fog-openstack version resolves this.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
